### PR TITLE
Fixing issue #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 ehthumbs.db
 Thumbs.db
 *~
+netbeans/

--- a/plugin.php
+++ b/plugin.php
@@ -5,8 +5,8 @@
 if (!defined("IN_ESOTALK")) exit;
 
 ET::$pluginInfo["Gravatar"] = array(
-	"name" => "Gravatar",
-	"description" => "Allows users to choose to use their Gravatar.",
+	"name" => T("Gravatar"),
+	"description" => T("Allows users to choose to use their Gravatar."),
 	"version" => ESOTALK_VERSION,
 	"author" => "Toby Zerner",
 	"authorEmail" => "support@esotalk.org",

--- a/plugin.php
+++ b/plugin.php
@@ -96,7 +96,7 @@ class ETPlugin_Gravatar extends ETPlugin {
 	 */
 	public function fieldGravatar($form)
 	{
-		return '<div class="gravatar-link">'.
+		return '<div class="gravatarLink" id="gravatarLink">'.
 			sprintf(T("Change your avatar on %s."), "<a href='http://gravatar.com' target='_blank'>Gravatar.com</a>") .
 		"</div>";
 	}
@@ -119,9 +119,9 @@ class ETPlugin_Gravatar extends ETPlugin {
 		$dataAttr = ($avatarFormat && $memberId) ? $this->getAvatarSrc($memberId, $avatarFormat) : "" ;
 		
 		return "<label class='checkbox'>" .
-		        $form->checkbox("useGravatar", array("id" => "gravatar-toggle", "data-gravatar-orig" => $dataAttr))." ".
+		        $form->checkbox("useGravatar", array("id" => "gravatarToggle", "data-gravatarOrig" => $dataAttr))." ".
 		        T("Use Gravatar instead of your own image")."</label> " .
-			      "<div class='gravatar-notice'><small>(" .
+			      "<div class='gravatarNotice'><small>(" .
 			      T("Note: This setting has no effect if you haven't uploaded your own image.") .
 		        ")</small></div>";
 	}

--- a/plugin.php
+++ b/plugin.php
@@ -41,13 +41,9 @@ class ETPlugin_Gravatar extends ETPlugin {
 				$url = "$protocol://www.gravatar.com/avatar/".md5(strtolower(trim($member["email"])))."?d=".urlencode($default)."&s=64";
 				return "<img src='$url' alt='' class='avatar $className'/>";
 			} else {
-				// FIXME: This is copy/pasted from the original avatar() function. A
-				// better way to override this is needed, in case avatar display mechanism
-				// changes at some point.
 				// Construct the avatar path from the provided information.
 				if (!empty($member["memberId"]) and !empty($member["avatarFormat"])) {
-					$file = "uploads/avatars/{$member["memberId"]}.{$member["avatarFormat"]}";
-					$url = getWebPath($file);
+					$url = ETPlugin_Gravatar::getUploadedAvatarSrc($member["memberId"], $member["avatarFormat"]);
 					return "<img src='$url' alt='' class='avatar $className'/>";
 				}
 				// Default to an avatar with the first letter of the member's name.
@@ -116,7 +112,7 @@ class ETPlugin_Gravatar extends ETPlugin {
 		$user = ET::$session->user;
 		$avatarFormat = isset($user["avatarFormat"]) ? $user["avatarFormat"] : "";
 		$memberId = isset($user["memberId"]) ? $user["memberId"] : "";
-		$dataAttr = ($avatarFormat && $memberId) ? $this->getAvatarSrc($memberId, $avatarFormat) : "" ;
+		$dataAttr = ($avatarFormat && $memberId) ? self::getUploadedAvatarSrc($memberId, $avatarFormat) : "" ;
 		
 		return "<label class='checkbox'>" .
 		        $form->checkbox("useGravatar", array("id" => "gravatarToggle", "data-gravatar-orig" => $dataAttr))." ".
@@ -185,7 +181,7 @@ class ETPlugin_Gravatar extends ETPlugin {
 	 * @param string $avatarFormat The avatar image format of current member
 	 * @return string              URL to the avatar image of current member
 	 */
-	protected function getAvatarSrc($memberId, $avatarFormat) {
+	public static function getUploadedAvatarSrc($memberId, $avatarFormat) {
 		return getWebPath("uploads/avatars/$memberId.$avatarFormat");
 	}
 	

--- a/plugin.php
+++ b/plugin.php
@@ -119,7 +119,7 @@ class ETPlugin_Gravatar extends ETPlugin {
 		$dataAttr = ($avatarFormat && $memberId) ? $this->getAvatarSrc($memberId, $avatarFormat) : "" ;
 		
 		return "<label class='checkbox'>" .
-		        $form->checkbox("useGravatar", array("id" => "gravatarToggle", "data-gravatarOrig" => $dataAttr))." ".
+		        $form->checkbox("useGravatar", array("id" => "gravatarToggle", "data-gravatar-orig" => $dataAttr))." ".
 		        T("Use Gravatar instead of your own image")."</label> " .
 			      "<div class='gravatarNotice'><small>(" .
 			      T("Note: This setting has no effect if you haven't uploaded your own image.") .

--- a/plugin.php
+++ b/plugin.php
@@ -33,24 +33,93 @@ class ETPlugin_Gravatar extends ETPlugin {
 		function avatar($member = array(), $className = "")
 		{
 			$default = C("plugin.Gravatar.default") ? C("plugin.Gravatar.default") : "mm";
-
+			$forceGravatar = C("plugin.Gravatar.forceGravatar") ? C("plugin.Gravatar.forceGravatar") : 0;
+			$useGravatar = isset($member["preferences"]["gravatar.useGravatar"]) ? $member["preferences"]["gravatar.useGravatar"] : 0;
 			$protocol = C("esoTalk.https") ? "https" : "http";
-			$url = "$protocol://www.gravatar.com/avatar/".md5(strtolower(trim($member["email"])))."?d=".urlencode($default)."&s=64";
 
-			return "<img src='$url' alt='' class='avatar $className'/>";
+			if (!$forceGravatar and !empty($member["memberId"]) and !empty($member["avatarFormat"])) {
+				$file = "uploads/avatars/{$member["memberId"]}.{$member["avatarFormat"]}";
+				$customAvatarUrl = getWebPath($file);
+				ET::$session->store("gravatar.customAvatarUrl", $customAvatarUrl);
+			} else {
+				$customAvatarUrl = '';
+			}
+			
+			if ($useGravatar || $forceGravatar || empty($member["avatarFormat"])) {
+				$url = "$protocol://www.gravatar.com/avatar/".md5(strtolower(trim($member["email"])))."?d=".urlencode($default)."&s=64";
+				return "<img src='$url' alt='' class='avatar $className'/>";
+			} else {
+				// FIXME: This is copy/pasted from the original avatar() function. A
+				// better way to do this is needed, in case avatar display mechanism
+				// changes at some point.
+				// Construct the avatar path from the provided information.
+				if ($customAvatarUrl != '') {
+					return "<img src='$customAvatarUrl' alt='' class='avatar $className'/>";
+				}
+
+				// Default to an avatar with the first letter of the member's name.
+				return "<span class='avatar $className'>".(!empty($member["username"]) ? mb_strtoupper(mb_substr($member["username"], 0, 1, "UTF-8"), "UTF-8") : "&nbsp;")."</span>";
+			}
 		}
+	}
+	
+	public function handler_settingsController_init($controller) {
+		$controller->addJSFile( $this->resource("gravatar.js") );
 	}
 
 	// Change the avatar field on the settings page.
 	function handler_settingsController_initGeneral($sender, $form)
 	{
-		$form->removeField("avatar", "avatar");
-		$form->addField("avatar", "avatar", array($this, "fieldAvatar"));
+		$forceGravatar = C("plugin.Gravatar.forceGravatar") ? C("plugin.Gravatar.forceGravatar") : 0;
+		
+		// Don't confuse members with the default avatar needed when they can't
+		// do nothing with it.
+		if ($forceGravatar == 1 ) {
+			$form->removeField("avatar", "avatar");
+		} else {
+			$form->setValue("useGravatar", ET::$session->preference("gravatar.useGravatar"));
+			$form->addField("avatar", "useGravatar", array($this, "fieldUseGravatar"), array($this, "saveGravatarPreference"));						
+		}
+		
+		$form->addField("avatar", "gravatar", array($this, "fieldGravatar"));
 	}
 
-	function fieldAvatar($form)
+	/**
+	 * Generates a link (and accompanying text) pointing to gravatar.com
+	 * 
+	 * @param ETForm $form The form object.
+	 * @return string
+	 */
+	public function fieldGravatar($form)
 	{
-		return sprintf(T("Change your avatar on %s."), "<a href='http://gravatar.com' target='_blank'>Gravatar.com</a>");
+		return '<div class="gravatar-link">'.
+			sprintf(T("Change your avatar on %s."), "<a href='http://gravatar.com' target='_blank'>Gravatar.com</a>") .
+		"</div>";
+	}
+	
+	/**
+	 * Generates a checkbox for Gravatar preference.
+	 * 
+	 * @param ETForm $form The form object.
+	 * @return string
+	 */
+	public function fieldUseGravatar($form)
+	{
+		$dataAttr = ET::$session->get("gravatar.customAvatarUrl", "");
+		return "<label class='checkbox'>" .$form->checkbox("useGravatar", array("id" => "gravatar-toggle", "data-gravatar-orig" => $dataAttr))." ".T("Use Gravatar instead of your own image")."</label> " .
+			"<div class='gravatar-notice'><small>(" . T("Note: This setting has no effect if you haven't uploaded your own image.") . ")</small></div>";
+	}
+	
+	/**
+	 * Saves the user's preference of using Gravatar or an image of their own.
+	 * 
+	 * @param ETForm $form The form object.
+	 * @param string $key The name of the field that was submitted.
+	 * @param array $preferences An array of preferences to write to the database.
+	 * @return void
+	 */
+	public function saveGravatarPreference($form, $key, &$preferences) {
+		$preferences['gravatar.useGravatar'] = (bool)$form->getValue($key);
 	}
 
 	/**
@@ -66,6 +135,7 @@ class ETPlugin_Gravatar extends ETPlugin {
 		$form = ETFactory::make("form");
 		$form->action = URL("admin/plugins/settings/Gravatar");
 		$form->setValue("default", C("plugin.Gravatar.default", "mm"));
+		$form->setValue("forceGravatar", C("plugin.Gravatar.forceGravatar", 0));
 
 		// If the form was submitted...
 		if ($form->validPostBack("save")) {
@@ -73,6 +143,7 @@ class ETPlugin_Gravatar extends ETPlugin {
 			// Construct an array of config options to write.
 			$config = array();
 			$config["plugin.Gravatar.default"] = $form->getValue("default");
+			$config["plugin.Gravatar.forceGravatar"] = $form->getValue("forceGravatar");
 
 			if (!$form->errorCount()) {
 
@@ -88,5 +159,5 @@ class ETPlugin_Gravatar extends ETPlugin {
 		$sender->data("gravatarSettingsForm", $form);
 		return $this->view("settings");
 	}
-
+	
 }

--- a/plugin.php
+++ b/plugin.php
@@ -78,7 +78,7 @@ class ETPlugin_Gravatar extends ETPlugin {
 		
 		if ($forceGravatar == 1 ) {
 			// Don't confuse members with the default avatar when they can't
-			// do nothing with it anyway.
+			// do anything with it anyway.
 			$form->removeField("avatar", "avatar");
 		} else {
 			$form->setValue("useGravatar", ET::$session->preference("gravatar.useGravatar"));
@@ -96,7 +96,7 @@ class ETPlugin_Gravatar extends ETPlugin {
 	 */
 	public function fieldGravatar($form)
 	{
-		return '<div class="gravatarLink" id="gravatarLink">'.
+		return "<div class='gravatarLink' id='gravatarLink'>".
 			sprintf(T("Change your avatar on %s."), "<a href='http://gravatar.com' target='_blank'>Gravatar.com</a>") .
 		"</div>";
 	}

--- a/resources/gravatar.js
+++ b/resources/gravatar.js
@@ -7,14 +7,14 @@
 				$(".avatarChooser").hide();
 				$("#gravatarLink").show();
 			} else {
-				if ($(el).data("gravatarOrig")) {
-					$(".avatarChooser img.avatar").attr("src", $(el).data("gravatarOrig"));
+				if ($(el).data("gravatar-orig")) {
+					$(".avatarChooser img.avatar").attr("src", $(el).data("gravatar-orig"));
 				}
 				$(".avatarChooser").show();
 				$("#gravatarLink").hide();
 			}
 		};
-		if ($cbox) {
+		if ($cbox.length > 0) {
 			$cbox.on("click", function(){
 				toggleAvatar(this);
 			});

--- a/resources/gravatar.js
+++ b/resources/gravatar.js
@@ -1,0 +1,20 @@
+;(function( $, window, document, undefined ) {
+	"use strict";
+	$(function(){
+		var $cbox = $("#gravatar-toggle");
+		var toggleAvatar = function(el){
+			if ($(el).prop("checked")) {
+				$(".avatarChooser").hide();
+			} else {
+				$(".avatarChooser").show();
+				if ($(el).data("gravatar-orig")) {
+					$(".avatarChooser img.avatar").attr("src", $(el).data("gravatar-orig"));
+				}
+			}
+		};
+		$cbox.on("click", function(){
+			toggleAvatar(this);
+		});
+		toggleAvatar($cbox);
+	});
+}( jQuery, window, document, undefined ));

--- a/resources/gravatar.js
+++ b/resources/gravatar.js
@@ -1,15 +1,17 @@
 ;(function( $, window, document, undefined ) {
 	"use strict";
 	$(function(){
-		var $cbox = $("#gravatar-toggle");
+		var $cbox = $("#gravatarToggle");
 		var toggleAvatar = function(el){
 			if ($(el).prop("checked")) {
 				$(".avatarChooser").hide();
+				$("#gravatarLink").show();
 			} else {
-				$(".avatarChooser").show();
-				if ($(el).data("gravatar-orig")) {
-					$(".avatarChooser img.avatar").attr("src", $(el).data("gravatar-orig"));
+				if ($(el).data("gravatarOrig")) {
+					$(".avatarChooser img.avatar").attr("src", $(el).data("gravatarOrig"));
 				}
+				$(".avatarChooser").show();
+				$("#gravatarLink").hide();
 			}
 		};
 		$cbox.on("click", function(){

--- a/resources/gravatar.js
+++ b/resources/gravatar.js
@@ -14,7 +14,7 @@
 				$("#gravatarLink").hide();
 			}
 		};
-		if ($box) {
+		if ($cbox) {
 			$cbox.on("click", function(){
 				toggleAvatar(this);
 			});

--- a/resources/gravatar.js
+++ b/resources/gravatar.js
@@ -14,9 +14,11 @@
 				$("#gravatarLink").hide();
 			}
 		};
-		$cbox.on("click", function(){
-			toggleAvatar(this);
-		});
-		toggleAvatar($cbox);
+		if ($box) {
+			$cbox.on("click", function(){
+				toggleAvatar(this);
+			});
+			toggleAvatar($cbox);
+		}
 	});
 }( jQuery, window, document, undefined ));

--- a/views/settings.php
+++ b/views/settings.php
@@ -21,6 +21,10 @@ $form = $data["gravatarSettingsForm"];
 #gravatarDefaults img {
 	display:block;
 }
+
+#gravatarForce label {
+	width: auto;
+}
 </style>
 
 <?php echo $form->open(); ?>
@@ -39,7 +43,9 @@ $form = $data["gravatarSettingsForm"];
 	<label class='radio'><?php echo $form->radio("default", "retro"); ?> <img src='http://www.gravatar.com/avatar/0?d=retro' class='avatar'> Retro</label>
 </div>
 </li>
-
+<li id="gravatarForce">
+	<label class="checkbox"><?php echo $form->checkbox("forceGravatar"); ?> <?php echo T("Force all members to use Gravatar"); ?></label>
+</li>
 </ul>
 
 </div>


### PR DESCRIPTION
Hi,

I have made some changes that enable members to choose whether to use Gravatar or not. I also added a checkbox on the plugin's settings page which, when checked, forces every member to use Gravatar.

If a member hasn't uploaded an image he/she will get the Gravatar regardless of his/her settings.

In addition, I have also added a tiny bit of JavaScript to members' Settings page that will hide their original (uploaded) avatar and/or the link to gravatar.com when appropriate. It also replaces the Gravatar image with the uploaded image when a member unchecks the "Use Gravatar instead of your own image" checkbox, because I felt it was confusing when it showed the Gravatar.

Three new translatable strings have been added:

``` php
$definitions["Force all members to use Gravatar"] = "Force all members to use Gravatar";
$definitions["Use Gravatar instead of your own image"] = "Use Gravatar instead of your own image";
$definitions["Note: This setting has no effect if you haven't uploaded your own image."] = "Note: This setting has no effect if you haven't uploaded your own image.";
```

I'm sure you want to suggest some improvements to them, as my use of the English language has become somewhat sloppy in recent years. Not enough practice, I'm afraid.

A question regarding line 139 in `plugin.php`: Should `gravatar.useGravatar` be `Gravatar.useGravatar` instead?
